### PR TITLE
Update example JSON and vehicles.meta files for new vehicles

### DIFF
--- a/PLOKS_CARS/data/[ACURA]/tltypes/vehicles.meta
+++ b/PLOKS_CARS/data/[ACURA]/tltypes/vehicles.meta
@@ -7,7 +7,7 @@
       <modelName>tltypes</modelName>
       <txdName>tltypes</txdName>
       <handlingId>tltypes</handlingId>
-      <gameName>TL Type S</gameName>
+      <gameName>tltypes</gameName>
       <vehicleMakeName>Acura</vehicleMakeName>
       <expressionDictName>null</expressionDictName>
       <expressionName>null</expressionName>

--- a/example_vmenu_addons.json
+++ b/example_vmenu_addons.json
@@ -109,7 +109,18 @@
     "golfgti7",
     "xc90",
     "lykan",
-    "wmfenyr"
+    "wmfenyr",
+    "tltypes",
+    "aaq4",
+    "q820",
+    "r820",
+    "rs6",
+    "ttrs",
+    "bolide",
+    "wildtrak",
+    "17civict",
+    "fk8",
+    "pm19"
   ],
   "peds": [
     "addonpedname1",


### PR DESCRIPTION
I made a Ruby script to ensure that all of the gameName attributes the modeName attributes for the purpose of vehicle names in vMenu. It also updates the example vmenu addons.json file.

The script is not part of this PR since I don't think it's needed, but it can be seen here: https://github.com/joe-p/FiveM-Civ-Car-Pack/blob/meta_update_script/meta_updates.rb